### PR TITLE
[fix] Fix Conv2d_BN fuse bug when groups > 1

### DIFF
--- a/levit.py
+++ b/levit.py
@@ -94,7 +94,7 @@ class Conv2d_BN(torch.nn.Sequential):
         w = c.weight * w[:, None, None, None]
         b = bn.bias - bn.running_mean * bn.weight / \
             (bn.running_var + bn.eps)**0.5
-        m = torch.nn.Conv2d(w.size(1), w.size(
+        m = torch.nn.Conv2d(w.size(1) * self.c.groups, w.size(
             0), w.shape[2:], stride=self.c.stride, padding=self.c.padding, dilation=self.c.dilation, groups=self.c.groups)
         m.weight.data.copy_(w)
         m.bias.data.copy_(b)

--- a/levit_c.py
+++ b/levit_c.py
@@ -94,7 +94,7 @@ class Conv2d_BN(torch.nn.Sequential):
         w = c.weight * w[:, None, None, None]
         b = bn.bias - bn.running_mean * bn.weight / \
             (bn.running_var + bn.eps)**0.5
-        m = torch.nn.Conv2d(w.size(1), w.size(
+        m = torch.nn.Conv2d(w.size(1) * self.c.groups, w.size(
             0), w.shape[2:], stride=self.c.stride, padding=self.c.padding, dilation=self.c.dilation, groups=self.c.groups)
         m.weight.data.copy_(w)
         m.bias.data.copy_(b)


### PR DESCRIPTION
Hi there, thanks for your great work : )

I found there is a bug when fusing Conv2d_BN with groups > 1. The reason is that the input channel should be `w.size(1) * self.c.groups` rather than `w.size(1)` in the function `Conv2d_BN.fuse`.

Reproduce Code:
```python
from levit import Conv2d_BN
from levit_c import Conv2d_BN as Conv2d_BN_c
import torch
import numpy as np
from itertools import product
import utils

@torch.no_grad()
def test():
    for layer_t, a, b, ks, groups in product(
        [Conv2d_BN, Conv2d_BN_c],
        [8, 16, 32, 64],
        [8, 16, 32, 64],
        [1, 3, 5, 7],
        [1, 2, 4],
            ):
        layer = layer_t(a, b, ks, pad=ks//2, groups=groups)
        layer.eval()

        x = torch.randn((1, a, 16, 16))
        y1 = layer(x)
        utils.replace_batchnorm(layer)
        y2 = layer(x)

        np.testing.assert_almost_equal(y1.detach().numpy(), y2.detach().numpy(), decimal=4)

if __name__ == '__main__':
    test()
    print("Test Over")
```

Error:
```
  File "test_conv.py", line 21, in test
    layer.fuse()
  File "/home/wkcn/miniconda3/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/wkcn/proj/LeViT-1/levit_c.py", line 99, in fuse
    m.weight.data.copy_(w)
RuntimeError: The size of tensor a (2) must match the size of tensor b (4) at non-singleton dimension 1
```